### PR TITLE
switch to roboto mono

### DIFF
--- a/data/index.php
+++ b/data/index.php
@@ -50,7 +50,7 @@ function get_title () {
     <meta charset="UTF-8">
     <meta name="fragment" content="!">
     <title><?php echo get_title (); ?></title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Droid+Serif:400|Droid+Sans+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Droid+Serif:400|Roboto+Mono:400,500,700">
     <link rel="stylesheet" href="/styles/main.css" type="text/css">
     <link rel="apple-touch-icon" href="/images/icon.png" />
     <link rel="shortcut icon" href="images/favicon.ico">

--- a/data/index.php
+++ b/data/index.php
@@ -50,7 +50,7 @@ function get_title () {
     <meta charset="UTF-8">
     <meta name="fragment" content="!">
     <title><?php echo get_title (); ?></title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Droid+Serif:400|Roboto+Mono:400,500,700">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Droid+Serif:400|Roboto+Mono:400,500,700,400italic">
     <link rel="stylesheet" href="/styles/main.css" type="text/css">
     <link rel="apple-touch-icon" href="/images/icon.png" />
     <link rel="shortcut icon" href="images/favicon.ico">

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -555,13 +555,13 @@ nav .subtitle {
 .main_code_definition {
     background-color: #eee;
     border-radius: 6px;
-    font-family: "Droid Sans Mono", monospace;
+    font-family: "Roboto Mono", monospace;
     margin: 12px;
     padding: 12px;
 }
 
 span.leaf_code_definition {
-    font-family: "Droid Sans Mono", monospace;
+    font-family: "Roboto Mono", monospace;
 }
 
 div.leaf_brief_description {
@@ -717,12 +717,12 @@ a.abstract_class,
 }
 
 .css_content_literal {
-    font-family: "Droid Sans Mono", monospace;
+    font-family: "Roboto Mono", monospace;
     color: #ff01ff;
 }
 
 code {
-    font-family: "Droid Sans Mono", monospace;
+    font-family: "Roboto Mono", monospace;
 }
 
 .main_code_definition a,


### PR DESCRIPTION
There are hardcoded b tags in the code so we need to use a font that supports bold weights. Droid sans mono does not. Roboto does. Fixes #46 